### PR TITLE
Add proper public testing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,22 @@ You can also set the `DEBUG` environment variable to `true` to have the
 application launch with the default log level set to `DEBUG` instead of `INFO`.
 
 Again, you can send `USR1` to toggle back to `INFO` as well.
+
+## Testing
+
+This package contains a public testing API you can use if you need to assert
+a log entry exists.
+
+```golang
+// TestNew calls New, but returns both the logger, and an observer that can be
+// used to fetch and compare delivered logs.
+TestNew(tb testing.TB, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs)
+```
+
+```golang
+// TestNewWithLevel is equal to TestNew, except that it takes an extra argument,
+// dictating the minimum log level required to record an entry in the recorder.
+TestNewWithLevel(tb testing.TB, level zapcore.LevelEnabler, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs)
+```
+
+see `testing.go` for more details.

--- a/logger.go
+++ b/logger.go
@@ -4,12 +4,10 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"testing"
 
 	"github.com/blendle/zapdriver"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 // New returns a new logger, ready to use in our services.
@@ -54,19 +52,6 @@ func Must(zaplog *zap.Logger, err error) *zap.Logger {
 	}
 
 	return zaplog
-}
-
-// TestNew calls New, but returns both the logger, and an observer that can be
-// used to fetch and compare delivered logs.
-func TestNew(tb testing.TB, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {
-	tb.Helper()
-
-	core, logs := observer.New(zapcore.DebugLevel)
-	opt := zap.WrapCore(func(_ zapcore.Core) zapcore.Core { return core })
-
-	zaplog := Must(New("test", "v0.0.1", append(options, opt)...))
-
-	return zaplog, logs
 }
 
 func levelToggler(level zap.AtomicLevel) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -24,15 +24,6 @@ func TestNew(t *testing.T) {
 	assert.IsType(t, &zap.Logger{}, logger)
 }
 
-func TestTestNew(t *testing.T) {
-	t.Parallel()
-
-	logger, logs := logger.TestNew(t)
-	logger.Debug("")
-
-	assert.Len(t, logs.All(), 1)
-}
-
 func TestLogger_Stackdriver_Labels(t *testing.T) {
 	t.Parallel()
 

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,30 @@
+package logger
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestNew calls New, but returns both the logger, and an observer that can be
+// used to fetch and compare delivered logs.
+func TestNew(tb testing.TB, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {
+	tb.Helper()
+
+	return TestNewWithLevel(tb, zapcore.DebugLevel, options...)
+}
+
+// TestNewWithLevel is equal to TestNew, except that it takes an extra argument,
+// dictating the minimum log level required to record an entry in the recorder.
+func TestNewWithLevel(tb testing.TB, level zapcore.LevelEnabler, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {
+	tb.Helper()
+
+	core, logs := observer.New(level)
+	opt := zap.WrapCore(func(_ zapcore.Core) zapcore.Core { return core })
+
+	zaplog := Must(New("test", "v0.0.1", append([]zap.Option{opt}, options...)...))
+
+	return zaplog, logs
+}

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,0 +1,46 @@
+package logger_test
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"go.uber.org/zap/zapcore"
+
+	logger "github.com/blendle/go-logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestNew(t *testing.T) {
+	t.Parallel()
+
+	logger, logs := logger.TestNew(t)
+	logger.Debug("")
+
+	assert.Len(t, logs.All(), 1)
+}
+
+func TestTestNewWithLevel(t *testing.T) {
+	t.Parallel()
+
+	logger, logs := logger.TestNewWithLevel(t, zapcore.ErrorLevel)
+	logger.Debug("")
+	logger.Warn("")
+	logger.Error("error")
+	logger.DPanic("dpanic")
+
+	require.Len(t, logs.All(), 2)
+	assert.Equal(t, zapcore.ErrorLevel, logs.All()[0].Level)
+	assert.Equal(t, zapcore.DPanicLevel, logs.All()[1].Level)
+}
+
+func TestTestNewWithLevel_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	logger, logs := logger.TestNewWithLevel(t, zapcore.WarnLevel, zap.Fields(zap.Int("1", 1)))
+	logger.Error("error")
+
+	require.Len(t, logs.All(), 1)
+	assert.Equal(t, int64(1), logs.All()[0].ContextMap()["1"])
+}


### PR DESCRIPTION
## Testing

This package contains a public testing API you can use if you need to assert
a log entry exists.

```golang
// TestNew calls New, but returns both the logger, and an observer that can be
// used to fetch and compare delivered logs.
TestNew(tb testing.TB, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs)
```

```golang
// TestNewWithLevel is equal to TestNew, except that it takes an extra argument,
// dictating the minimum log level required to record an entry in the recorder.
TestNewWithLevel(tb testing.TB, level zapcore.LevelEnabler, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs)
```

see `testing.go` for more details.
