### PR TITLE
Add "TestNewWarn" convenience function

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -16,6 +16,16 @@ func TestNew(tb testing.TB, options ...zap.Option) (*zap.Logger, *observer.Obser
 	return TestNewWithLevel(tb, zapcore.DebugLevel, options...)
 }
 
+// TestNewWarn is equal to TestNew, except that it sets the minimum log level
+// required to record an entry in the recorder to "Warn". This convenience
+// function can be used to validate that no warnings, or errors are logged when
+// testing a unit of code.
+func TestNewWarn(tb testing.TB, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {
+	tb.Helper()
+
+	return TestNewWithLevel(tb, zapcore.WarnLevel, options...)
+}
+
 // TestNewWithLevel is equal to TestNew, except that it takes an extra argument,
 // dictating the minimum log level required to record an entry in the recorder.
 func TestNewWithLevel(tb testing.TB, level zapcore.LevelEnabler, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {

--- a/testing_test.go
+++ b/testing_test.go
@@ -21,14 +21,27 @@ func TestTestNew(t *testing.T) {
 	assert.Len(t, logs.All(), 1)
 }
 
+func TestTestNewWarn(t *testing.T) {
+	t.Parallel()
+
+	logger, logs := logger.TestNewWarn(t)
+	logger.Debug("")
+	logger.Warn("")
+	logger.Error("")
+
+	require.Len(t, logs.All(), 2)
+	assert.Equal(t, zapcore.WarnLevel, logs.All()[0].Level)
+	assert.Equal(t, zapcore.ErrorLevel, logs.All()[1].Level)
+}
+
 func TestTestNewWithLevel(t *testing.T) {
 	t.Parallel()
 
 	logger, logs := logger.TestNewWithLevel(t, zapcore.ErrorLevel)
 	logger.Debug("")
 	logger.Warn("")
-	logger.Error("error")
-	logger.DPanic("dpanic")
+	logger.Error("")
+	logger.DPanic("")
 
 	require.Len(t, logs.All(), 2)
 	assert.Equal(t, zapcore.ErrorLevel, logs.All()[0].Level)


### PR DESCRIPTION
TestNewWarn is equal to TestNew, except that it sets the minimum log level
required to record an entry in the recorder to "Warn". This convenience
function can be used to validate that no warnings, or errors are logged when
testing a unit of code.
