### PR TITLE
Allow explicitly disabling debug logging

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -26,7 +26,7 @@ func New(service, version string, options ...zap.Option) (*zap.Logger, error) {
 		config.Development = true
 	}
 
-	if _, ok := os.LookupEnv("DEBUG"); ok {
+	if v := os.Getenv("DEBUG"); v != "" && v != "0" && v != "false" {
 		level.SetLevel(zap.DebugLevel)
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -81,6 +81,16 @@ func TestLogger_Debug_Enabled(t *testing.T) {
 	assert.True(t, logger.Core().Enabled(zapcore.DebugLevel))
 }
 
+func TestLogger_Debug_Explicitly_Disabled(t *testing.T) {
+	_ = os.Setenv("DEBUG", "0")
+	defer func() { _ = os.Unsetenv("DEBUG") }()
+
+	logger := logger.Must(logger.New("", ""))
+
+	assert.False(t, logger.Core().Enabled(zapcore.DebugLevel))
+	assert.True(t, logger.Core().Enabled(zapcore.InfoLevel))
+}
+
 func TestLogger_Debug_Disabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`DEBUG=false` and `DEBUG=0` now mean the same as not setting `DEBUG` at all. This helps in situations where you want to conditionally set the value of `DEBUG`, but it's more difficult to conditionally set, or completely omit the `DEBUG` variable.