### PR TITLE
Require explicit development mode

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -22,7 +22,7 @@ func New(service, version string, options ...zap.Option) (*zap.Logger, error) {
 		ErrorOutputPaths: []string{"stderr"},
 	}
 
-	if env, ok := os.LookupEnv("ENV"); ok && env != "production" {
+	if os.Getenv("ENV") == "development" {
 		config.Development = true
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -34,28 +34,28 @@ func TestLogger_Stackdriver_Labels(t *testing.T) {
 	assert.NotNil(t, logs.All()[0].ContextMap()["labels"])
 }
 
-func TestLogger_Development_NonProduction(t *testing.T) {
-	_ = os.Setenv("ENV", "non-production")
+func TestLogger_DevelopmentEnv(t *testing.T) {
+	_ = os.Setenv("ENV", "development")
 	defer func() { _ = os.Unsetenv("ENV") }()
 
 	logger, logs := logger.TestNew(t)
 	fn := func() { logger.DPanic("") }
 
-	// because we've set the environment to anything other than "production", any
-	// `DPanic` log call will cause a panic.
+	// because we've set the environment to "development", any `DPanic` log call
+	// will cause a panic.
 	assert.Panics(t, fn)
 	assert.Len(t, logs.All(), 1)
 }
 
-func TestLogger_Development_Production(t *testing.T) {
-	_ = os.Setenv("ENV", "production")
+func TestLogger_DevelopmentWrongEnv(t *testing.T) {
+	_ = os.Setenv("ENV", "not-development")
 	defer func() { _ = os.Unsetenv("ENV") }()
 
 	logger, logs := logger.TestNew(t)
 	fn := func() { logger.DPanic("") }
 
-	// because we've set the environment to "production", any `DPanic` log call
-	// will not cause a panic.
+	// because we've set the environment to anything other than "development", any
+	// `DPanic` log call will not cause a panic.
 	assert.NotPanics(t, fn)
 	assert.Len(t, logs.All(), 1)
 }
@@ -69,6 +69,18 @@ func TestLogger_Development_Unset(t *testing.T) {
 	// because we haven't set the "ENV" environment variable, any `DPanic` log
 	// call will not cause a panic.
 	assert.NotPanics(t, fn)
+	assert.Len(t, logs.All(), 1)
+}
+
+func TestLogger_Development_Option(t *testing.T) {
+	t.Parallel()
+
+	logger, logs := logger.TestNew(t, zap.Development())
+	fn := func() { logger.DPanic("") }
+
+	// because we've passed in `zap.Development()`, any `DPanic` log call will
+	// cause a panic.
+	assert.Panics(t, fn)
 	assert.Len(t, logs.All(), 1)
 }
 


### PR DESCRIPTION
Before, anything other than `ENV=production` would set the logger in
development mode. This is somewhat "dangerous", as it means that if
you don't set this variable correctly, Zap's log sampler is disabled,
potentially causing millions of lines to be logged, causing an
application to crawl to a halt.

With this change, only `ENV=development` sets this flag. You can
still enable this manually:

```golang
logger.New("my-app", "v1.0.0", zap.Development())
```